### PR TITLE
Fix crash when dealloc

### DIFF
--- a/Classes/PRSlideView.m
+++ b/Classes/PRSlideView.m
@@ -430,6 +430,10 @@ CGFloat const kPRSlideViewPageControlHeight = 17.f;
     return self;
 }
 
+- (void)dealloc {
+    [_scrollView removeObserver:self forKeyPath:NSStringFromSelector(@selector(contentOffset))];
+}
+
 /*
 // Only override drawRect: if you perform custom drawing.
 // An empty implementation adversely affects performance during animation.


### PR DESCRIPTION
When an observer is finished listening for changes on an object, it is
expected to call `–removeObserver:forKeyPath:context:`.